### PR TITLE
Fix typo in .module file.

### DIFF
--- a/tm_project_gallery.module
+++ b/tm_project_gallery.module
@@ -7,7 +7,7 @@ use Drupal\views\ViewExecutable;
 */
 function tm_project_gallery_views_pre_render(ViewExecutable $view) {
   if (isset($view) && ($view->storage->id() == 'projects')) {
-    $view->element['#attached']['library'][] = 'tm_projects_gallery/project-gallery-views';
+    $view->element['#attached']['library'][] = 'tm_project_gallery/project-gallery-views';
   }
 }
 


### PR DESCRIPTION
The library path for the node CSS was mispelled. Fixed typo to make node CSS accessible to solve #1.